### PR TITLE
Fix steamcmd stuck after crash due to failing to upload dump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN         dpkg --add-architecture i386 \
                 gettext-base \
                 ca-certificates \
                 numactl \
+                libcurl3-gnutls:i386 \
                 libssl-dev \
                 lib32gcc-s1 \
                 libsdl2-2.0-0 \


### PR DESCRIPTION
Add `libcurl3-gnutls:i386` to Dockerfile